### PR TITLE
BREAKING CHANGES: Remove `webview_inviter_name`

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -3,6 +3,5 @@ export interface Workspace {
   connect_partner_name?: string
   name: string
   is_sandbox: boolean
-  webview_inviter_name?: string
   webview_inviter_logo_url?: string
 }


### PR DESCRIPTION
I highly doubt this value has been used elsewhere, so this is practically a no-op.