### PR TITLE
Add API lock type

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -72,7 +72,7 @@ export type NoiseDetectedEvent =
   CommonDeviceEvent<"noise_detection.detected_noise">
 
 // Locks
-export type LockMethod = "keycode" | "manual" | "unknown"
+export type LockMethod = "keycode" | "manual" | "seam-connect-api" | "unknown"
 export type LockLockedEvent = CommonDeviceEvent<
   "lock.locked",
   {


### PR DESCRIPTION
Can be used when `/locks/lock_door` is called on Seam Connect.
