### PR TITLE
Add an optional pre-redirect acknowledgement for redirect panes

### DIFF
--- a/src/panes.ts
+++ b/src/panes.ts
@@ -53,6 +53,7 @@ export type RedirectPane = Pane<
   "redirect_pane",
   {
     redirect_url: string
+    pre_redirect_acknowledgement?: boolean
   },
   {
     callback_args: Record<string, string>


### PR DESCRIPTION
We have two different cases where we use a redirect pane:
- When we are finished with a webview and redirect to a customer-specific finish screen (for ex. Hospitable wants this) - in this case, we do want to show our finish screen, and then redirect to the Hospitable screen
- When we are using an OAuth-based provider (like Nuki), we just want to immediately redirect to the provider's authorization screen without any acknowledgement before the redirect

This is a flag to allow both cases to exist and work properly (right now the OAuth case does not work properly)