### PR TITLE
Allow an alternative action to be invoked on a redirect pane

### DIFF
--- a/src/panes.ts
+++ b/src/panes.ts
@@ -58,7 +58,8 @@ export type RedirectPane = Pane<
     provider?: ProviderMetadata
   },
   {
-    callback_args: Record<string, string>
+    callback_args?: Record<string, string>
+    alternative_action?: string
   }
 >
 


### PR DESCRIPTION
Used in the SmartThings webview to show a redirect pane that takes them to the default OAuth-based flow, but allows the alternative PAT-based flow to be invoked instead of the redirect.