### PR TITLE
feat: add battery status changed event - issue 2423

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -29,6 +29,13 @@ export type DeviceLowBatteryEvent = CommonDeviceEvent<
     battery_level: number
   }
 >
+export type DeviceBatteryStatusChanged = CommonDeviceEvent<
+  "device.battery_status_changed",
+  {
+    battery_status: string
+    battery_level: number
+  }
+>
 export type DeviceCodeLimitReachedEvent =
   CommonDeviceEvent<"device.code_limit_reached">
 
@@ -122,6 +129,7 @@ export type SeamEvent =
   | DeviceDisconnectEvent
   | DeviceTamperEvent
   | DeviceLowBatteryEvent
+  | DeviceBatteryStatusChanged
   | CreateAccessCodeEvent
   | ChangeAccessCodeEvent
   | SetOnDeviceAccessCodeEvent


### PR DESCRIPTION
Adding Battery Status Changed event type so it can be imported into seam-connect. To help with this issue:
https://github.com/seamapi/seam-connect/issues/2423