### PR TITLE
Add is_completed for finished_pane

### DIFF
--- a/src/panes.ts
+++ b/src/panes.ts
@@ -135,7 +135,7 @@ export type FinishedPane = Pane<
   "finished_pane",
   {
     custom_redirect_url?: string
-    is_completed?: boolean
+    is_final?: boolean
     context?: {
       smartthings_auth?: {
         locations: SmartThingsLocation[]
@@ -143,7 +143,9 @@ export type FinishedPane = Pane<
       }
     }
   },
-  {}
+  {
+    finalize?: boolean
+  }
 >
 
 export type AnyPane =

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -135,6 +135,7 @@ export type FinishedPane = Pane<
   "finished_pane",
   {
     custom_redirect_url?: string
+    is_completed?: boolean
     context?: {
       smartthings_auth?: {
         locations: SmartThingsLocation[]


### PR DESCRIPTION
This is used for `finished_pane`s in SmartThings webviews in which the user might continue after the `finished_pane` in order to connect additional locations. If they click a final "Done" button on the `finished_pane`, the next `finished_pane` will be sent with a `is_completed` set to true, otherwise it's set to `false` for SmartThings webviews

(waiting for RFC before merge https://github.com/seamapi/rfc/pull/69)