### PR TITLE
api: Add `BrandSelectPane`

### DIFF
--- a/src/panes.ts
+++ b/src/panes.ts
@@ -84,7 +84,14 @@ export type SearchAndSelectPane = Pane<
 
 export type BrandSelectPane = Pane<
   "brand_select_pane",
-  {},
+  {
+    options: Array<{
+      label: string
+      sublabel?: string
+      value: string
+      image_url?: string
+    }>
+  },
   {
     brand: string
   }
@@ -161,6 +168,7 @@ export type AnyPane =
   | LoadingPane
   | RedirectPane
   | SearchAndSelectPane
+  | BrandSelectPane
   | LoginPane
   | InitiateTwoFactorPane
   | TwoFactorPane

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -82,6 +82,14 @@ export type SearchAndSelectPane = Pane<
   { value: string | string[] }
 >
 
+export type BrandSelectPane = Pane<
+  "brand_select_pane",
+  {},
+  {
+    brand: string
+  }
+>
+
 export type LoginPane = Pane<
   "login_pane",
   {

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -89,7 +89,7 @@ export type BrandSelectPane = Pane<
       label: string
       sublabel?: string
       value: string
-      image_url?: string
+      image_url: string
     }>
   },
   {


### PR DESCRIPTION
The customizations for the connect webview now necessitate a specific pane just for brand selection. The generic `SearchAndSelectPane` is used in different contexts and the new brand selection UI invalidates the selection-based approach of that component. As such, a new, specific pane needs to be added—this adds a new type for that pane and adds it to `AnyPane` so that `seam-connect` and `seam-connect-webview` won't complain.