### PR TITLE
fix: Remove extra asterisk in comment

### DIFF
--- a/src/panes.ts
+++ b/src/panes.ts
@@ -37,7 +37,7 @@ type Pane<
     scheduling_link?: string
   }
   submit_props: PaneSubmitProps
-  /** Timestamp last time pane was changed in ISO8601 format */
+  /* Timestamp last time pane was changed in ISO8601 format */
   last_updated_at: string
 }
 


### PR DESCRIPTION
This is primarily to trigger a version bump since I didn't prefix my commit with `fix:` or `feat:` in PR #49 (thanks @rchodava for letting me know).

If there was a better method of triggering a new version, let me know and I can close this.