### PR TITLE
fix: Add Igloo Auth to Finished Pane

### DIFF
--- a/src/panes.ts
+++ b/src/panes.ts
@@ -157,6 +157,9 @@ export type FinishedPane = Pane<
         locations: SmartThingsLocation[]
         oauth_redirect?: string
       }
+      igloodeveloper_auth?: {
+        igloo_webhook_url: string
+      }
     }
   },
   {


### PR DESCRIPTION
Pass the webhook url to the end, since webview will include instructions, we can't reuse existing panes.