### PR TITLE
fix: add kwikset_no_mfa_auth as a type of LoginPane.context

### DIFF
--- a/src/panes.ts
+++ b/src/panes.ts
@@ -86,7 +86,7 @@ export type LoginPane = Pane<
   "login_pane",
   {
     accepted_user_identifiers: Array<"email" | "phone" | "username">
-    context?: "smartthings_pre_auth"
+    context?: "smartthings_pre_auth" | "kwikset_no_mfa_auth"
     default_user_identifier?: string
     provider: ProviderMetadata
   },


### PR DESCRIPTION
Add kwikset_no_mfa_auth as a type of LoginPane.context, will be used to dynamically trigger connect webview notice to disable MFA (e.g. face ID)