### PR TITLE
Cloud Url Credential Type

### DIFF
--- a/src/panes.ts
+++ b/src/panes.ts
@@ -102,7 +102,9 @@ export type BrandSelectPane = Pane<
 export type LoginPane = Pane<
   "login_pane",
   {
-    accepted_user_identifiers: Array<"email" | "phone" | "username" | "cloud_url">
+    accepted_user_identifiers: Array<
+      "email" | "phone" | "username" | "cloud_url"
+    >
     /** @deprecated - use a more specific property than context for dynamic rendering logic */
     context?: "smartthings_pre_auth"
     credential?: "password" | "api_key"

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -107,7 +107,7 @@ export type LoginPane = Pane<
     >
     /** @deprecated - use a more specific property than context for dynamic rendering logic */
     context?: "smartthings_pre_auth"
-    credential?: "password" | "api_key"
+    credential?: "password" | "api_key" | "access_token"
     default_user_identifier?: string
     provider: ProviderMetadata
   },

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -102,7 +102,7 @@ export type BrandSelectPane = Pane<
 export type LoginPane = Pane<
   "login_pane",
   {
-    accepted_user_identifiers: Array<"email" | "phone" | "username">
+    accepted_user_identifiers: Array<"email" | "phone" | "username" | "cloud_url">
     /** @deprecated - use a more specific property than context for dynamic rendering logic */
     context?: "smartthings_pre_auth"
     credential?: "password" | "api_key"


### PR DESCRIPTION
This is to support Hubitat. To connect a hubitat hub, the user has to login to the dashboard (which is a hosted on LAN), set up the "Maker API", and give us at a minimum their `hub_id`, `app_id`, and access_token. 

I think the easiest way to do that is to ask the user to grab one of the cloud URLs they are given when they set up the app, they look like this:

https://cloud.hubitat.com/api/23823a56-846f-4c8a-9ad5-ffb03e9226fe/apps/4/devices/[Device ID]?access_token=0a94ca51-34fd-4cbf-bf46-c5d5015c7df6

[See here for more details](https://www.notion.so/2023-05-01-Hubitat-x-YDM273-Manual-fdeb95f5fc7644b7ae05fc867cf2b41d?pvs=4#764c303bad9a4f299fa76633c5b78286)

The connect webview will ask for any of the cloud urls and the access token. If the cloud url provided has the `access_token` query parameter, then we can just auto-populate that input field. 

All just implementation details for later this week, just wanted to give all the context
