### PR TITLE
fix: Add device conversion events to union

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -172,6 +172,8 @@ export type SeamEvent =
   | UnmanagedDeviceConnectedEvent
   | DeviceDisconnectEvent
   | UnmanagedDeviceDisconnectEvent
+  | DeviceConvertedToUnmanagedEvent
+  | UnmanagedDeviceConvertedToManagedEvent
   | DeviceTamperEvent
   | DeviceLowBatteryEvent
   | DeviceBatteryStatusChanged


### PR DESCRIPTION
I forget this step every time.