### PR TITLE
Add `help_link` and `help_text` to fields, `description` prop for the header

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -5,6 +5,8 @@ export type Field<Type extends string, Props, Input> = {
     name: string
     type: Type
     is_disabled?: boolean
+    help_link?: string
+    help_text?: string
   } & Props
   input: Input
 }

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -142,8 +142,6 @@ export type FieldsPane = Pane<
       title: string
       provider?: ProviderMetadata
     }
-    help_link?: string
-    help_text?: string
   },
   Record<string, AnyField["input"]>
 >

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -141,6 +141,7 @@ export type FieldsPane = Pane<
     header: {
       title: string
       provider?: ProviderMetadata
+      description?: string
     }
   },
   Record<string, AnyField["input"]>

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -136,12 +136,14 @@ export type FieldsPane = Pane<
   "fields_pane",
   {
     fields: AnyField["props"][]
-    context?: "brivo_auth" | "hubitat_auth"
+    context?: "brivo_auth"
     submit_label?: string
     header: {
       title: string
       provider?: ProviderMetadata
     }
+    help_link?: string
+    help_text?: string
   },
   Record<string, AnyField["input"]>
 >

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -136,7 +136,7 @@ export type FieldsPane = Pane<
   "fields_pane",
   {
     fields: AnyField["props"][]
-    context?: "brivo_auth"
+    context?: "brivo_auth" | "hubitat_auth"
     submit_label?: string
     header: {
       title: string


### PR DESCRIPTION
Adding this because I'm adding some custom text to the hubitat fields pane.

Is this the right way to do this? I saw it dones this way brivo, but it makes a bit more sense to me to just check the provider name. 

https://hello-seam.slack.com/archives/C04RHHUGTFA/p1688689199666139

![Screen Shot 2023-07-06 at 5 19 49 PM](https://github.com/seamapi/seamapi-types/assets/11382084/a55ad069-7fcf-42df-a1a7-79f4c20d6fa6)
