### PR TITLE
feat(events.ts): add CommonEnrollmentAutomationEvent interface and EnrollmentAutomationDeletedEvent type

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -267,6 +267,22 @@ export interface CommonPhoneEvent<
 
 export type PhoneDeactivatedEvent = CommonPhoneEvent<"phone.deactivated">
 
+export interface CommonEnrollmentAutomationEvent<
+  EventType extends string,
+  Payload extends Record<string, unknown> | {} = {}
+> {
+  event_type: EventType
+  payload: Payload & {
+    workspace_id: string
+    enrollment_automation_id: string
+  }
+  created_at: string
+  occurred_at: string
+}
+
+export type EnrollmentAutomationDeletedEvent =
+  CommonEnrollmentAutomationEvent<"enrollment_automation.deleted">
+
 export type SeamEvent =
   | DeviceConnectedEvent
   | UnmanagedDeviceConnectedEvent
@@ -317,3 +333,4 @@ export type SeamEvent =
   | PhoneDeactivatedEvent
   | AcsCredentialDeleted
   | AcsUserDeleted
+  | EnrollmentAutomationDeletedEvent


### PR DESCRIPTION
This commit introduces a new interface `CommonEnrollmentAutomationEvent` to represent a generic structure for enrollment automation events, including a new event type `EnrollmentAutomationDeletedEvent`.


supports https://github.com/seamapi/seam-connect/issues/5694