### PR TITLE
add user user identity id to client session event

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -220,6 +220,7 @@ export interface CommonClientSessionEvent<
   payload: Payload & {
     workspace_id: string
     connected_account_id?: string
+    user_identity_id?: string
     client_session_id: string
   }
   created_at: string


### PR DESCRIPTION
- make 'connected_account_id' optional for CommonClientSessionEvent
- fix: add user_identity_id to client_session event
