### PR TITLE
fix: Add DeviceDeletedEvent to SeamEvent

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -311,6 +311,7 @@ export type SeamEvent =
   | DeviceLowBatteryEvent
   | DeviceBatteryStatusChanged
   | DeviceRemovedEvent
+  | DeviceDeletedEvent
   | CreateAccessCodeEvent
   | ChangeAccessCodeEvent
   | ScheduledOnDeviceAccessCodeEvent


### PR DESCRIPTION
Svix is missing the `device.deleted` event. To add this I need to first add it to seamapi-types interface. The type exists but it's not part of `SeamEvent` currently. See: https://github.com/seamapi/seam-connect/issues/6021