### PR TITLE
Make `connected_account_id` on device events optional

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -5,7 +5,7 @@ export interface CommonDeviceEvent<
   event_type: EventType
   payload: Payload & {
     workspace_id: string
-    connected_account_id: string
+    connected_account_id?: string
     device_id: string
   }
   created_at: string


### PR DESCRIPTION
Devices are not guarenteed to have a connected account.

See https://hello-seam.slack.com/archives/C05M2RMJS2V/p1711499945680809.
